### PR TITLE
Fixed product-id and variation-id attribute updates

### DIFF
--- a/plattar-ar-adapter/package.json
+++ b/plattar-ar-adapter/package.json
@@ -44,8 +44,8 @@
     "@plattar/plattar-web": "^1.123.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.17.0",
-    "@babel/core": "^7.17.2",
+    "@babel/cli": "^7.17.3",
+    "@babel/core": "^7.17.4",
     "@babel/preset-env": "^7.16.11",
     "browserify": "^17.0.0",
     "typescript": "^4.5.5",

--- a/plattar-ar-adapter/src/embed/controllers/product-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/product-controller.ts
@@ -34,7 +34,9 @@ export class ProductController extends PlattarController {
             if (viewer) {
                 const variationID: string | null = this.getAttribute("variation-id");
 
-                viewer.messenger.selectVariation(variationID);
+                if (variationID && viewer.messenger) {
+                    viewer.messenger.selectVariation(variationID);
+                }
             }
 
             return;

--- a/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
@@ -35,7 +35,9 @@ export class ViewerController extends PlattarController {
                 const productID: string | null = this.getAttribute("product-id");
                 const variationID: string | null = this.getAttribute("variation-id");
 
-                viewer.messenger.selectVariation(productID, variationID);
+                if (productID && variationID && viewer.messenger) {
+                    viewer.messenger.selectVariation(productID, variationID);
+                }
             }
 
             return;


### PR DESCRIPTION
- This PR fixes an issue where selectVariation can be called on `<plattar-viewer />` and `<plattar-product />` nodes when `product-id`,`variation-id` or messenger are undefined.