### PR TITLE
Implement SceneProduct ID support when Scene ID is present

### DIFF
--- a/plattar-ar-adapter/src/ar/scene-product-ar.ts
+++ b/plattar-ar-adapter/src/ar/scene-product-ar.ts
@@ -1,0 +1,61 @@
+import { ProductAR } from "./product-ar";
+import { SceneProduct } from "@plattar/plattar-api";
+import { Util } from "../util/util";
+import { LauncherAR } from "./launcher-ar";
+
+/**
+ * Allows launching Product AR by providing a SceneProduct ID instead.
+ * SceneProducts are much more convenient to grab from the Plattar CMS
+ */
+export class SceneProductAR extends ProductAR {
+
+    private readonly _sceneProductID: string;
+
+    // this is evaluated in the init() function
+    private _attachedProductID: string | null = null;
+
+    constructor(sceneProductID: string | undefined | null = null, variationID: string | undefined | null = null) {
+        super(sceneProductID, variationID);
+
+        if (!sceneProductID) {
+            throw new Error("SceneProductAR.constructor(sceneProductID, variationID) - sceneProductID must be defined");
+        }
+
+        this._sceneProductID = sceneProductID;
+    }
+
+    public get sceneProductID(): string {
+        return this._sceneProductID;
+    }
+
+    public get productID(): string {
+        if (!this._attachedProductID) {
+            throw new Error("SceneProductAR.productID() - product id was not defined, did you call init()?");
+        }
+
+        return this._attachedProductID;
+    }
+
+    public init(): Promise<LauncherAR> {
+        return new Promise<LauncherAR>((accept, reject) => {
+            if (!Util.canAugment()) {
+                return reject(new Error("SceneProductAR.init() - cannot proceed as AR not available in context"));
+            }
+
+            const sceneProduct: SceneProduct = new SceneProduct(this.sceneProductID);
+
+            sceneProduct.get().then((sceneProduct: SceneProduct) => {
+                const productID: string = sceneProduct.attributes.product_id;
+
+                if (!productID) {
+                    return reject("SceneProductAR.init() - Scene Product does not have an attached Product instance");
+                }
+
+                this._attachedProductID = productID;
+
+                // execute the standard Product AR functionality
+                return super.init().then(accept).catch(reject);
+            }).catch(reject);
+        });
+    }
+}

--- a/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
@@ -1,6 +1,7 @@
 import { Server } from "@plattar/plattar-api";
 import { LauncherAR } from "../../ar/launcher-ar";
 import { ProductAR } from "../../ar/product-ar";
+import { SceneProductAR } from "../../ar/scene-product-ar";
 import { Util } from "../../util/util";
 import { ControllerState, PlattarController } from "./plattar-controller";
 
@@ -32,7 +33,7 @@ export class ViewerController extends PlattarController {
             const viewer: any | null = this._element;
 
             if (viewer) {
-                const productID: string | null = this.getAttribute("product-id");
+                const productID: string | null = (this.getAttribute("product-id") || this.getAttribute("scene-product-id"));
                 const variationID: string | null = this.getAttribute("variation-id");
 
                 if (productID && variationID && viewer.messenger) {
@@ -78,7 +79,7 @@ export class ViewerController extends PlattarController {
                 let dst: string = Server.location().base + "renderer/viewer.html?scene_id=" + sceneID;
 
                 // optional attributes
-                const productID: string | null = this.getAttribute("product-id");
+                const productID: string | null = (this.getAttribute("product-id") || this.getAttribute("scene-product-id"));
                 const variationID: string | null = this.getAttribute("variation-id");
 
                 if (productID) {
@@ -129,7 +130,7 @@ export class ViewerController extends PlattarController {
                 viewer.setAttribute("scene-id", sceneID);
 
                 // optional attributes
-                const productID: string | null = this.getAttribute("product-id");
+                const productID: string | null = (this.getAttribute("product-id") || this.getAttribute("scene-product-id"));
                 const variationID: string | null = this.getAttribute("variation-id");
 
                 if (productID) {
@@ -164,6 +165,7 @@ export class ViewerController extends PlattarController {
 
             const productID: string | null = this.getAttribute("product-id");
 
+            // use product-id if available
             if (productID) {
                 const variationID: string | null = this.getAttribute("variation-id");
 
@@ -172,14 +174,25 @@ export class ViewerController extends PlattarController {
                 return product.init().then(accept).catch(reject);
             }
 
+            const sceneProductID: string | null = this.getAttribute("scene-product-id");
+
+            // use scene-product-id if available
+            if (sceneProductID) {
+                const variationID: string | null = this.getAttribute("variation-id");
+
+                const product: SceneProductAR = new SceneProductAR(sceneProductID, variationID);
+
+                return product.init().then(accept).catch(reject);
+            }
+
             const sceneID: string | null = this.getAttribute("scene-id");
 
             // otherwise, scene was set so use SceneAR
             if (sceneID) {
-                return reject(new Error("ViewerController.initAR() - AR mode for scene-id not yet supported, use product-id"));
+                return reject(new Error("ViewerController.initAR() - AR mode for scene-id not yet supported, use product-id or scene-product-id"));
             }
 
-            return reject(new Error("ViewerController.initAR() - minimum required attributes not set, use scene-id or product-id as a minimum"));
+            return reject(new Error("ViewerController.initAR() - minimum required attributes not set, use product-id or scene-product-id as a minimum"));
         });
     }
 

--- a/plattar-ar-adapter/src/index.ts
+++ b/plattar-ar-adapter/src/index.ts
@@ -3,6 +3,7 @@ export * as PlattarQRCode from "@plattar/plattar-qrcode";
 
 export * as version from "./version";
 export { ProductAR } from "./ar/product-ar";
+export { SceneProductAR } from "./ar/scene-product-ar";
 export { SceneAR } from "./ar/scene-ar";
 export { ModelAR } from "./ar/model-ar";
 export { RawAR } from "./ar/raw-ar";


### PR DESCRIPTION
- See Issue #22
- Implemented SceneProductAR and integrated with ViewerController. Embeds can now specify `scene-product-id` to launch AR from
- Note that SceneProductAR does not use the Scene Transforms for the AR, this is for convenience only as getting Scene Product ID is easier from a curated Scene