### PR TITLE
Add QR Code customisation attribute support

### DIFF
--- a/plattar-ar-adapter/package.json
+++ b/plattar-ar-adapter/package.json
@@ -45,11 +45,11 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",
-    "@babel/core": "^7.18.2",
+    "@babel/core": "^7.18.5",
     "@babel/preset-env": "^7.18.2",
     "browserify": "^17.0.0",
-    "typescript": "^4.6.4",
-    "uglify-js": "^3.15.5"
+    "typescript": "^4.7.3",
+    "uglify-js": "^3.16.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plattar-ar-adapter/src/embed/controllers/configurator-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/configurator-controller.ts
@@ -36,7 +36,7 @@ export class ConfiguratorController extends PlattarController {
             const sceneID: string | null = this.getAttribute("scene-id");
 
             if (sceneID) {
-                const opt: any = options || PlattarController.DEFAULT_QR_OPTIONS;
+                const opt: any = options || this._GetDefaultQROptions();
 
                 const viewer: HTMLElement = document.createElement("plattar-qrcode");
 
@@ -58,6 +58,8 @@ export class ConfiguratorController extends PlattarController {
                 if (opt.qrType) {
                     viewer.setAttribute("qr-type", opt.qrType);
                 }
+
+                viewer.setAttribute("shorten", (opt.shorten && (opt.shorten === true || opt.shorten === "true")) ? "true" : "false");
 
                 let dst: string = Server.location().base + "renderer/configurator.html?scene_id=" + sceneID;
 

--- a/plattar-ar-adapter/src/embed/controllers/plattar-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/plattar-controller.ts
@@ -15,10 +15,11 @@ export abstract class PlattarController {
     /**
      * Default QR Code rendering options
      */
-    public static get DEFAULT_QR_OPTIONS(): any {
+    protected _GetDefaultQROptions(): any {
         return {
-            color: "#101721",
-            qrType: "default",
+            color: this.getAttribute("qr-color") || "#101721",
+            qrType: this.getAttribute("qr-style") || "default",
+            shorten: this.getAttribute("qr-shorten") || false,
             margin: 0
         }
     };
@@ -89,7 +90,7 @@ export abstract class PlattarController {
             // remove the old renderer instance if any
             this.removeRenderer();
 
-            const opt: any = options || PlattarController.DEFAULT_QR_OPTIONS;
+            const opt: any = options || this._GetDefaultQROptions();
 
             const viewer: HTMLElement = document.createElement("plattar-qrcode");
 
@@ -111,6 +112,8 @@ export abstract class PlattarController {
             if (opt.qrType) {
                 viewer.setAttribute("qr-type", opt.qrType);
             }
+
+            viewer.setAttribute("shorten", (opt.shorten && (opt.shorten === true || opt.shorten === "true")) ? "true" : "false");
 
             const qrOptions: string = btoa(JSON.stringify(opt));
 

--- a/plattar-ar-adapter/src/embed/controllers/product-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/product-controller.ts
@@ -47,7 +47,7 @@ export class ProductController extends PlattarController {
             const productID: string | null = this.getAttribute("product-id");
 
             if (productID) {
-                const opt: any = options || PlattarController.DEFAULT_QR_OPTIONS;
+                const opt: any = options || this._GetDefaultQROptions();
 
                 const viewer: HTMLElement = document.createElement("plattar-qrcode");
 
@@ -69,6 +69,8 @@ export class ProductController extends PlattarController {
                 if (opt.qrType) {
                     viewer.setAttribute("qr-type", opt.qrType);
                 }
+
+                viewer.setAttribute("shorten", (opt.shorten && (opt.shorten === true || opt.shorten === "true")) ? "true" : "false");
 
                 // optional attributes
                 const variationID: string | null = this.getAttribute("variation-id");

--- a/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/viewer-controller.ts
@@ -51,7 +51,7 @@ export class ViewerController extends PlattarController {
             const sceneID: string | null = this.getAttribute("scene-id");
 
             if (sceneID) {
-                const opt: any = options || PlattarController.DEFAULT_QR_OPTIONS;
+                const opt: any = options || this._GetDefaultQROptions();
 
                 const viewer: HTMLElement = document.createElement("plattar-qrcode");
 
@@ -73,6 +73,8 @@ export class ViewerController extends PlattarController {
                 if (opt.qrType) {
                     viewer.setAttribute("qr-type", opt.qrType);
                 }
+
+                viewer.setAttribute("shorten", (opt.shorten && (opt.shorten === true || opt.shorten === "true")) ? "true" : "false");
 
                 let dst: string = Server.location().base + "renderer/viewer.html?scene_id=" + sceneID;
 

--- a/plattar-ar-adapter/src/embed/controllers/vto-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/vto-controller.ts
@@ -35,7 +35,7 @@ export class VTOController extends PlattarController {
             const sceneID: string | null = this.getAttribute("scene-id");
 
             if (sceneID) {
-                const opt: any = options || PlattarController.DEFAULT_QR_OPTIONS;
+                const opt: any = options || this._GetDefaultQROptions();
 
                 const viewer: HTMLElement = document.createElement("plattar-qrcode");
 
@@ -57,6 +57,8 @@ export class VTOController extends PlattarController {
                 if (opt.qrType) {
                     viewer.setAttribute("qr-type", opt.qrType);
                 }
+
+                viewer.setAttribute("shorten", (opt.shorten && (opt.shorten === true || opt.shorten === "true")) ? "true" : "false");
 
                 let dst: string = Server.location().base + "renderer/facear.html?scene_id=" + sceneID;
 


### PR DESCRIPTION
- See Issue #42
- Note: Manually generated and passed variables to `startQRCode()` function will always override user-set attributes on the node