### PR TITLE
Add support for selective AR objects

### DIFF
--- a/plattar-ar-adapter/package.json
+++ b/plattar-ar-adapter/package.json
@@ -41,14 +41,14 @@
     "@plattar/plattar-api": "^1.120.1",
     "@plattar/plattar-qrcode": "1.134.1",
     "@plattar/plattar-services": "^1.120.1",
-    "@plattar/plattar-web": "^1.135.1"
+    "@plattar/plattar-web": "^1.135.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",
     "@babel/core": "^7.18.13",
     "@babel/preset-env": "^7.18.10",
     "browserify": "^17.0.0",
-    "typescript": "^4.7.4",
+    "typescript": "^4.8.2",
     "uglify-js": "^3.17.0"
   },
   "publishConfig": {


### PR DESCRIPTION
- See Issue #47
- Added support for SceneModels to be included as part of AR
- Added support for optional AR object types that are enabled/disabled via the Plattar CMS
- NOTE: Adding SceneModels suddenly to Scene AR may cause regressions, added `critical change` card against