### PR TITLE
Allow using scene-product-id and variation-id when launching VTO AR

### DIFF
--- a/plattar-ar-adapter/package.json
+++ b/plattar-ar-adapter/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-env": "^7.19.4",
     "browserify": "^17.0.0",
     "typescript": "^4.8.4",
-    "uglify-js": "^3.17.3"
+    "uglify-js": "^3.17.4"
   },
   "publishConfig": {
     "access": "public"

--- a/plattar-ar-adapter/src/ar/scene-ar.ts
+++ b/plattar-ar-adapter/src/ar/scene-ar.ts
@@ -98,21 +98,25 @@ export class SceneAR extends LauncherAR {
                 const selection: SceneVariationSelection = this._variationSelection;
 
                 // we have a specific product selection
-                if (sceneProduct.attributes.include_in_augment && product && (product.id === selection.productID && selection.variationID)) {
-                    configurator.addSceneProduct(sceneProduct.id, selection.variationID);
-
-                    totalARObjectCount++;
-                }
-                else if (sceneProduct.attributes.include_in_augment && product) {
-                    if ((sceneProduct.id === selection.sceneProductID) && selection.variationID) {
+                if (sceneProduct.attributes.include_in_augment) {
+                    // check if this product is the one we want (from selection optionally)
+                    if (product && (product.id === selection.productID) && selection.variationID) {
                         configurator.addSceneProduct(sceneProduct.id, selection.variationID);
 
                         totalARObjectCount++;
                     }
-                    else if (product.attributes.product_variation_id) {
-                        configurator.addSceneProduct(sceneProduct.id, product.attributes.product_variation_id);
+                    else if (product) {
+                        // check if this scene-product is the one we want (from selection)
+                        if ((sceneProduct.id === selection.sceneProductID) && selection.variationID) {
+                            configurator.addSceneProduct(sceneProduct.id, selection.variationID);
 
-                        totalARObjectCount++;
+                            totalARObjectCount++;
+                        }
+                        else if (product.attributes.product_variation_id) {
+                            configurator.addSceneProduct(sceneProduct.id, product.attributes.product_variation_id);
+
+                            totalARObjectCount++;
+                        }
                     }
                 }
             });

--- a/plattar-ar-adapter/src/ar/scene-ar.ts
+++ b/plattar-ar-adapter/src/ar/scene-ar.ts
@@ -8,6 +8,12 @@ import RealityViewer from "../viewers/reality-viewer";
 import SceneViewer from "../viewers/scene-viewer";
 import { LauncherAR } from "./launcher-ar";
 
+export interface SceneVariationSelection {
+    readonly sceneProductID?: string;
+    readonly productID?: string;
+    readonly variationID?: string;
+}
+
 /**
  * Performs AR functionality related to Plattar Scenes
  */
@@ -18,12 +24,13 @@ export class SceneAR extends LauncherAR {
 
     // scene and selected variation IDs
     private readonly _sceneID: string;
+    private readonly _variationSelection: SceneVariationSelection;
 
     // this thing controls the actual AR view
     // this is setup via .init() function
     private _ar: ARViewer | null;
 
-    constructor(sceneID: string | undefined | null = null) {
+    constructor(sceneID: string | undefined | null = null, variationSelection: SceneVariationSelection | undefined | null = null) {
         super();
 
         if (!sceneID) {
@@ -31,6 +38,7 @@ export class SceneAR extends LauncherAR {
         }
 
         this._sceneID = sceneID;
+        this._variationSelection = variationSelection || {};
         this._ar = null;
     }
 
@@ -87,11 +95,25 @@ export class SceneAR extends LauncherAR {
             // add our scene products
             sceneProducts.forEach((sceneProduct: SceneProduct) => {
                 const product: Product | undefined = sceneProduct.relationships.find(Product);
+                const selection: SceneVariationSelection = this._variationSelection;
 
-                if (sceneProduct.attributes.include_in_augment && product && product.attributes.product_variation_id) {
-                    configurator.addSceneProduct(sceneProduct.id, product.attributes.product_variation_id);
+                // we have a specific product selection
+                if (sceneProduct.attributes.include_in_augment && product && (product.id === selection.productID && selection.variationID)) {
+                    configurator.addSceneProduct(sceneProduct.id, selection.variationID);
 
                     totalARObjectCount++;
+                }
+                else if (sceneProduct.attributes.include_in_augment && product) {
+                    if ((sceneProduct.id === selection.sceneProductID) && selection.variationID) {
+                        configurator.addSceneProduct(sceneProduct.id, selection.variationID);
+
+                        totalARObjectCount++;
+                    }
+                    else if (product.attributes.product_variation_id) {
+                        configurator.addSceneProduct(sceneProduct.id, product.attributes.product_variation_id);
+
+                        totalARObjectCount++;
+                    }
                 }
             });
 

--- a/plattar-ar-adapter/src/embed/controllers/vto-controller.ts
+++ b/plattar-ar-adapter/src/embed/controllers/vto-controller.ts
@@ -65,6 +65,9 @@ export class VTOController extends PlattarController {
                 // optional attributes
                 const configState: string | null = this.getAttribute("config-state");
                 const showAR: string | null = this.getAttribute("show-ar");
+                const productID: string | null = this.getAttribute("product-id");
+                const sceneProductID: string | null = this.getAttribute("scene-product-id");
+                const variationID: string | null = this.getAttribute("variation-id");
 
                 if (configState) {
                     dst += "&config_state=" + configState;
@@ -72,6 +75,18 @@ export class VTOController extends PlattarController {
 
                 if (showAR) {
                     dst += "&show_ar=" + showAR;
+                }
+
+                if (productID) {
+                    dst += "&product_id=" + productID;
+                }
+
+                if (sceneProductID) {
+                    dst += "&scene_product_id=" + sceneProductID;
+                }
+
+                if (variationID) {
+                    dst += "&variation_id=" + variationID;
                 }
 
                 viewer.setAttribute("url", opt.url || dst);
@@ -116,6 +131,9 @@ export class VTOController extends PlattarController {
                 // optional attributes
                 const configState: string | null = this.getAttribute("config-state");
                 const showAR: string | null = this.getAttribute("show-ar");
+                const productID: string | null = this.getAttribute("product-id");
+                const sceneProductID: string | null = this.getAttribute("scene-product-id");
+                const variationID: string | null = this.getAttribute("variation-id");
 
                 if (configState) {
                     viewer.setAttribute("config-state", configState);
@@ -123,6 +141,18 @@ export class VTOController extends PlattarController {
 
                 if (showAR) {
                     viewer.setAttribute("show-ar", showAR);
+                }
+
+                if (productID) {
+                    viewer.setAttribute("product-id", productID);
+                }
+
+                if (sceneProductID) {
+                    viewer.setAttribute("scene-product-id", sceneProductID);
+                }
+
+                if (variationID) {
+                    viewer.setAttribute("variation-id", variationID);
                 }
 
                 viewer.onload = () => {
@@ -261,7 +291,15 @@ export class VTOController extends PlattarController {
         // otherwise no config-state or viewer is active
         // fallback to using default SceneAR implementation
         if (sceneID) {
-            const sceneAR: SceneAR = new SceneAR(sceneID);
+            const productID: string | null = this.getAttribute("product-id");
+            const sceneProductID: string | null = this.getAttribute("scene-product-id");
+            const variationID: string | null = this.getAttribute("variation-id");
+
+            const sceneAR: SceneAR = new SceneAR(sceneID, {
+                productID: productID ? productID : undefined,
+                sceneProductID: sceneProductID ? sceneProductID : undefined,
+                variationID: variationID ? variationID : undefined
+            });
 
             sceneAR.init().then(accept).catch(reject);
 


### PR DESCRIPTION
- See Issue #53
- Added support for scene-product-id, product-id and variation-id for facear renderer
- Added support for scene-product-id, product-id and variation-id for facear qrcode renderer
- Added support for scene-product-id, product-id and variation-id for facear SceneAR launcher
- Updated packages